### PR TITLE
unbundle boost, xerces-c, gmock, gtest and zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,31 +39,16 @@ set( CMAKE_OSX_DEPLOYMENT_TARGET "10.9" )
 # Universal builds for mac
 # set( CMAKE_OSX_ARCHITECTURES "i386;x86_64" )
 
-
-# The parsing order is significant!
-
-add_subdirectory( src/BoostParts )
-# Set these so zipios doesn't complain.
-set( Boost_DATE_TIME_LIBRARY 1 )
-set( Boost_FILESYSTEM_LIBRARY 1 )
-set( Boost_PROGRAM_OPTIONS_LIBRARY 1 )
-set( Boost_REGEX_LIBRARY 1 )
-set( Boost_SYSTEM_LIBRARY 1 )
-set( Boost_THREAD_LIBRARY 1 )
-set( BOOST_LIBS BoostParts )
-set( BOOST_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src/BoostParts )
-
-add_subdirectory( src/Xerces )
-set( XERCES_LIBRARIES Xerces )
-set( XERCES_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src/Xerces )
+FIND_PACKAGE(Boost REQUIRED COMPONENTS date_time filesystem program_options regex system thread)
+FIND_PACKAGE(XercesC 3.1)
+FIND_PACKAGE(GTest)
+FIND_PACKAGE(ZLIB)
 
 add_subdirectory( src/XercesExtensions )
 set( XERCESEXTENSIONS_LIBRARIES XercesExtensions )
 set( XERCESEXTENSIONS_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src/XercesExtensions )
 
-add_subdirectory( src/zlib )
 add_subdirectory( src/zipios )
-add_subdirectory( src/googlemock )
 
 add_subdirectory( src/FlightCrew )
 set( FLIGHTCREW_LIBRARIES FlightCrew )

--- a/src/FlightCrew-cli/CMakeLists.txt
+++ b/src/FlightCrew-cli/CMakeLists.txt
@@ -30,7 +30,7 @@ create_source_groups( SOURCES )
 # We need to pick up the stdafx.h file
 # and the headers for the linked-to libraries
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}
-                     ${BoostParts_SOURCE_DIR}
+                     ${Boost_INCLUDE_DIRS}
                      ${FlightCrew_SOURCE_DIR}
                      ${XercesExtensions_SOURCE_DIR}
                      )

--- a/src/FlightCrew-gui/CMakeLists.txt
+++ b/src/FlightCrew-gui/CMakeLists.txt
@@ -82,7 +82,7 @@ create_source_groups( RAW_SOURCES )
 include_directories( BEFORE
                      ${CMAKE_CURRENT_SOURCE_DIR}
                      ${CMAKE_CURRENT_BINARY_DIR}
-                     ${BoostParts_SOURCE_DIR}
+                     ${Boost_INCLUDE_DIRS}
                      ${FlightCrew_SOURCE_DIR}
                      ${XercesExtensions_SOURCE_DIR}
                      )

--- a/src/FlightCrew-plugin/CMakeLists.txt
+++ b/src/FlightCrew-plugin/CMakeLists.txt
@@ -30,7 +30,7 @@ create_source_groups( SOURCES )
 # We need to pick up the stdafx.h file
 # and the headers for the linked-to libraries
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}
-                     ${BoostParts_SOURCE_DIR}
+                     ${Boost_INCLUDE_DIRS}
                      ${FlightCrew_SOURCE_DIR}
                      ${XercesExtensions_SOURCE_DIR}
                      )

--- a/src/FlightCrew/CMakeLists.txt
+++ b/src/FlightCrew/CMakeLists.txt
@@ -50,8 +50,8 @@ list( REMOVE_ITEM SOURCES ${to_remove} )
 
 # creating PCH's for MSVC and GCC on Linux
 include( ${CMAKE_SOURCE_DIR}/cmake_extras/CustomPCH.cmake )
-set( ALL_INCLUDES ${BoostParts_SOURCE_DIR}
-                  ${Xerces_SOURCE_DIR}
+set( ALL_INCLUDES ${Boost_INCLUDE_DIRS}
+                  ${XercesC_INCLUDE_DIRS}
                   ${zipios_SOURCE_DIR} )
 set( GCC_PCH_TARGET gccPCH_fc )
 
@@ -65,8 +65,8 @@ precompiled_header( SOURCES ALL_INCLUDES ${GCC_PCH_TARGET} ${PCH_NAME} )
 include_directories( ${CMAKE_CURRENT_BINARY_DIR}
                      ${CMAKE_CURRENT_SOURCE_DIR}
                      ../zipios 
-                     ../BoostParts 
-                     ../Xerces
+                     ${Boost_INCLUDE_DIRS}
+                     ${XercesC_INCLUDE_DIRS}
                      ../XercesExtensions
                      ../utf8-cpp
                    )
@@ -82,7 +82,7 @@ else()
     add_library( ${PROJECT_NAME} ${SOURCES} )
 endif()
 
-target_link_libraries( ${PROJECT_NAME} zipios BoostParts XercesExtensions )
+target_link_libraries( ${PROJECT_NAME} zipios ${Boost_LIBRARIES} XercesExtensions )
 
 #############################################################################
 

--- a/src/FlightCrew/tests/CMakeLists.txt
+++ b/src/FlightCrew/tests/CMakeLists.txt
@@ -42,20 +42,20 @@ list( REMOVE_ITEM TEST_SOURCES ${to_remove} )
 # So techincally we don't need to include Xerces etc.
 include_directories( ${CMAKE_CURRENT_BINARY_DIR} 
                      ${CMAKE_CURRENT_SOURCE_DIR} 
-                     ../../BoostParts 
-                     ../../Xerces 
+                     ${Boost_INCLUDE_DIRS}
+                     ${XercesC_INCLUDE_DIRS}
                      ../../XercesExtensions 
-                     ../../googlemock/include
-                     ../../googlemock/gtest/include
+                     /usr/include/gmock
+                     ${GTEST_INCLUDE_DIRS}
                    )
 
-link_directories ( ${PROJECT_BINARY_DIR}/lib ) 
+link_directories ( ${PROJECT_BINARY_DIR}/lib ${GTEST_BOTH_LIBRARIES} ) 
 
 #############################################################################
 
 # creating PCH's for MSVC and GCC on Linux
 include( ${CMAKE_SOURCE_DIR}/cmake_extras/CustomPCH.cmake )
-set( ALL_INCLUDES ${gtest_SOURCE_DIR}/include ${BoostParts_SOURCE_DIR} )
+set( ALL_INCLUDES ${GTEST_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} )
 
 set( GCC_PCH_TARGET gccPCH_tests )
 
@@ -65,7 +65,7 @@ precompiled_header( TEST_SOURCES ALL_INCLUDES ${GCC_PCH_TARGET} ${PCH_NAME} )
 
 add_executable( ${PROJECT_NAME} ${TEST_SOURCES} )
 
-target_link_libraries( ${PROJECT_NAME} FlightCrew gmock )
+target_link_libraries( ${PROJECT_NAME} FlightCrew gmock ${GTEST_BOTH_LIBRARIES} )
 
 #############################################################################
 

--- a/src/XercesExtensions/CMakeLists.txt
+++ b/src/XercesExtensions/CMakeLists.txt
@@ -16,14 +16,14 @@ file( GLOB SOURCES *.cpp *.h )
 # We need to pick up the stdafx.h file
 # and the headers for the linked-to libraries
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}
-                     ${XERCES_INCLUDE_DIRS}
-                     ${BOOST_INCLUDE_DIRS} )
+                     ${XercesC_INCLUDE_DIRS}
+                     ${Boost_INCLUDE_DIRS} )
 
 link_directories ( ${PROJECT_BINARY_DIR}/lib ) 
 
 add_library( ${PROJECT_NAME} ${SOURCES} )
 
-target_link_libraries( ${PROJECT_NAME} ${XERCES_LIBRARIES} )
+target_link_libraries( ${PROJECT_NAME} ${XercesC_LIBRARIES} )
 
 #############################################################################
 

--- a/src/utf8-cpp/utf8/core.h
+++ b/src/utf8-cpp/utf8/core.h
@@ -29,7 +29,7 @@ DEALINGS IN THE SOFTWARE.
 #define UTF8_FOR_CPP_CORE_H_2675DCD0_9480_4c0c_B92A_CC14C027B731
 
 #include <iterator>
-#include "../../BoostParts/boost/cstdint.hpp"
+#include "/usr/include/boost/cstdint.hpp"
 
 namespace utf8
 {

--- a/src/zipios/CMakeLists.txt
+++ b/src/zipios/CMakeLists.txt
@@ -16,16 +16,15 @@ file( GLOB_RECURSE SOURCES *.cpp *.h )
 # We need to pick up the stdafx.h file
 # and the headers for the linked-to libraries
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}
-                     ${BoostParts_SOURCE_DIR}
-                     ${zlib_SOURCE_DIR}
-                     ${zlib_BINARY_DIR}
+                     ${Boost_INCLUDE_DIRS}
+                     ${ZLIB_INCLUDE_DIRS}
                      )
 
 link_directories ( ${PROJECT_BINARY_DIR}/lib )
 
 add_library( ${PROJECT_NAME} ${SOURCES} )
 
-target_link_libraries( ${PROJECT_NAME} zlib BoostParts )
+target_link_libraries( ${PROJECT_NAME} ${ZLIB_LIBRARIES} ${Boost_LIBRARIES} )
 
 #############################################################################
 


### PR DESCRIPTION
This commit unbundles Boost, Xerces-c, Gmock, Gtest and Zlib from FlightCrew. All of those are fairly common on modern distros and there's no reason to bundle it with FlightCrew.
I created the original patch while creating an ebuild (package) for the Gentoo Linux distribution.

Note that all tests run fine; as well as flightcrew-{cli,gui}. However loading the plugin from Sigil 0.9.4 fails with the error that flightcrew-plugin is not a sigil plugin.

Also, to compile cleanly, -std=c++11 needs to be passed. (Tested with GCC-5.3).
